### PR TITLE
Add support for Hostnames

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+Contributions are welcome! Please submit a PR. Please ensure the tests pass before submitting a PR.

--- a/README.md
+++ b/README.md
@@ -26,3 +26,9 @@ func main() {
   }
 }
 ```
+
+## Changelog
+- [gopkg.in/polds/logrus-papertrail-hook.v1](https://godoc.org/gopkg.in/polds/logrus-papertrail-hook.v1)
+    - Unchanged from split from [logrus](https://github.com/Sirupsen/logrus)
+- [gopkg.in/polds/logrus-papertrail-hook.v2](https://godoc.org/gopkg.in/polds/logrus-papertrail-hook.v2)
+    - Adds support for custom hostnames. Major API change.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Papertrail Hook for Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:" /> [![Build Status](https://travis-ci.org/polds/logrus-papertrail-hook.svg)](https://travis-ci.org/polds/logrus-papertrail-hook)&nbsp;[![godoc reference](https://godoc.org/github.com/polds/logrus-papertrail-hook?status.png)](https://godoc.org/gopkg.in/polds/logrus-papertrail-hook.v0)
+# Papertrail Hook for Logrus <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:" /> [![Build Status](https://travis-ci.org/polds/logrus-papertrail-hook.svg)](https://travis-ci.org/polds/logrus-papertrail-hook)&nbsp;[![godoc reference](https://godoc.org/github.com/polds/logrus-papertrail-hook?status.png)](https://godoc.org/gopkg.in/polds/logrus-papertrail-hook.v2)
 
 [Papertrail](https://papertrailapp.com) provides hosted log management. Once stored in Papertrail, you can [group](http://help.papertrailapp.com/kb/how-it-works/groups/) your logs on various dimensions, [search](http://help.papertrailapp.com/kb/how-it-works/search-syntax) them, and trigger [alerts](http://help.papertrailapp.com/kb/how-it-works/alerts).
 
@@ -14,12 +14,12 @@ For `YOUR_APP_NAME`, substitute a short string that will readily identify your a
 import (
   "log/syslog"
   "github.com/Sirupsen/logrus"
-  "github.com/polds/logrus-papertrail-hook"
+  "gopkg.in/polds/logrus-papertrail-hook.v2"
 )
 
 func main() {
   log       := logrus.New()
-  hook, err := logrus_papertrail.NewPapertrailHook("logs.papertrailapp.com", YOUR_PAPERTRAIL_UDP_PORT, YOUR_APP_NAME)
+  hook, err := logrus_papertrail.NewPapertrailHook(&logrus_papertrail.Hook{"logs.papertrailapp.com", YOUR_PAPERTRAIL_UDP_PORT, YOUR_HOST_NAME, YOUR_APP_NAME})
 
   if err == nil {
     log.Hooks.Add(hook)

--- a/papertrail_test.go
+++ b/papertrail_test.go
@@ -12,7 +12,12 @@ func TestWritingToUDP(t *testing.T) {
 	port := 16661
 	udp.SetAddr(fmt.Sprintf(":%d", port))
 
-	hook, err := NewPapertrailHook("localhost", port, "test")
+	hook, err := NewPapertrailHook(&Hook{
+		Host:     "localhost",
+		Port:     port,
+		HostName: "test.local",
+		AppName:  "test",
+	})
 	if err != nil {
 		t.Errorf("Unable to connect to local UDP server.")
 	}


### PR DESCRIPTION
Radically changes the API for this, instead of passing named fields you now pass the `Hook` object. Now supports the ability to set custom hostnames. As of present it is up to the user to define the hostname to use. Previous iterations of similar functionality determined the hostname on behalf of the user, now it is up to the user to do so.
