### PR TITLE
Fix example of proper initialization of struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,12 @@ import (
 
 func main() {
   log       := logrus.New()
-  hook, err := logrus_papertrail.NewPapertrailHook(&logrus_papertrail.Hook{"logs.papertrailapp.com", YOUR_PAPERTRAIL_UDP_PORT, YOUR_HOST_NAME, YOUR_APP_NAME})
+  hook, err := logrus_papertrail.NewPapertrailHook(&logrus_papertrail.Hook{
+    Host: "logs.papertrailapp.com",
+    Port: YOUR_PAPERTRAIL_UDP_PORT,
+    Hostname: YOUR_HOST_NAME,
+    Appname: YOUR_APP_NAME
+  })
 
   if err == nil {
     log.Hooks.Add(hook)


### PR DESCRIPTION
Need to use named literals since there are non-exported fields in the struct.

Ref: http://blog.tquadrado.com/2014/go-struct-initialization-with-named-literals/
