### PR TITLE
Add TCP/TLS option for hook

### DIFF
--- a/papertrail_test.go
+++ b/papertrail_test.go
@@ -43,11 +43,30 @@ func TestReal(t *testing.T) {
 		Appname:  "myapp",
 	})
 	if err != nil {
-		t.Errorf("Unable to connect to Papertrail")
+		t.Errorf("Unable to connect to Papertrail via UDP")
 	}
 
 	log := logrus.New()
 	log.Hooks.Add(hook)
 
-	log.Infoln("testing")
+	log.Infoln("testing UDP")
+}
+
+func TestRealTCP(t *testing.T) {
+	port, _ := strconv.Atoi(os.Getenv("PAPERTRAIL_PORT"))
+
+	hook, err := logrus_papertrail.NewPapertrailTCPHook(&logrus_papertrail.Hook{
+		Host:     os.Getenv("PAPERTRAIL_HOST"),
+		Port:     port,
+		Hostname: "appserver",
+		Appname:  "myapp",
+	})
+	if err != nil {
+		t.Errorf("Unable to connect to Papertrail via TCP")
+	}
+
+	log := logrus.New()
+	log.Hooks.Add(hook)
+
+	log.Infoln("testing TCP")
 }


### PR DESCRIPTION
I avoided making any breaking changes to the NewPapertrailHook method and instead just added NewPapertrailTCPHook.

Note that since the final parameter in tls.Dial is set to `nil`, this connection should use the default root set of the current operating system. If you'd like to provide your own Root PEM, you can use this example provided by Google: https://golang.org/pkg/crypto/tls/#example_Dial
