### PR TITLE
Revert to sirupsen -> Sirupsen

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ For `YOUR_APP_NAME`, substitute a short string that will readily identify your a
 ```go
 import (
   "log/syslog"
-  "github.com/sirupsen/logrus"
+  "github.com/Sirupsen/logrus"
   "gopkg.in/polds/logrus-papertrail-hook.v2"
 )
 

--- a/papertrail.go
+++ b/papertrail.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 )
 
 const (

--- a/papertrail_test.go
+++ b/papertrail_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/sirupsen/logrus"
+	"github.com/Sirupsen/logrus"
 	"github.com/stvp/go-udp-testing"
 )
 


### PR DESCRIPTION
As discussed on the issue https://github.com/polds/logrus-papertrail-hook/issues/8, using import path both of `github.com/logrus/sirupsen` and `github.com/logrus/Sirupsen` might occur `case-insensitive import collision` error...

The name changing was reverted on https://github.com/sirupsen/logrus/commit/26809363aac4cc10d49171447009ac6bccc9c655 .

I checked hooks for logrus, most of them including [official Syslog hook](https://github.com/sirupsen/logrus/blob/master/hooks/syslog/syslog.go#L7) use `github.com/logrus/Sirupsen`, so I would like to standardize the naming to `Sirupsen` to avoid the error . 💓 